### PR TITLE
[FEAT] #42 이상훈

### DIFF
--- a/baekjoon/boj_2531_hoon.java
+++ b/baekjoon/boj_2531_hoon.java
@@ -1,0 +1,43 @@
+```java
+import java.io.*;
+import java.util.HashMap;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int d = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+
+        int[] arr = new int[N];
+        for(int i=0; i<N; i++){
+            int num = Integer.parseInt(br.readLine());
+            arr[i] = num;
+        }
+
+        HashMap<Integer, Integer> map = new HashMap<>();
+        map.put(c, 1);
+        for(int i=0; i<k; i++){
+            map.put(arr[i], map.getOrDefault(arr[i], 0)+1);
+        }
+        int maxType = map.size();
+
+        int idx = k;
+        for(int i=idx; i<N+k; i++){
+            // 다시 원점 돌아오면 반복문 탈출
+            if(i%N==k-1)
+                break;
+            map.put(arr[i%N], map.getOrDefault(arr[i%N], 0)+1);
+            map.put(arr[(i-k+N)%N], map.get(arr[(i-k+N)%N])-1);
+            if(map.get(arr[(i-k+N)%N])==0)
+                map.remove(arr[(i-k+N)%N]);
+            maxType = Math.max(maxType, map.size());
+        }
+        System.out.println(maxType);
+    }
+}
+```


### PR DESCRIPTION
N이 최대 30000이고, 이중 for문을 사용할 경우 최대 9억 번의 연산이 필요하므로 시간 초과가 발생합니다.
이를 해결하기 위해 슬라이딩 윈도우를 사용하여 한 번의 for문으로 최적화하였습니다.

1. 처음 k개의 초밥을 map에 저장합니다.
2. 쿠폰 번호에 해당하는 초밥을 map에 저장합니다.
3. 슬라이딩 윈도우를 수행하며 새로운 초밥을 추가하고 가장 오래된 초밥을 제거합니다.
4. map.size()로 초밥의 최대 가짓수를 갱신합니다.

한바퀴 돌때까지 3, 4 과정을 반복합니다.

시간복잡도 : O(n)(30만)