### PR TITLE
[FEAT] #46 이상훈

### DIFF
--- a/baekjoon/boj_1202_hoon.md
+++ b/baekjoon/boj_1202_hoon.md
@@ -1,0 +1,73 @@
+```java
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+
+    public static class Jewel {
+        int weight;
+        int price;
+
+        public Jewel(int weight, int price){
+            this.weight = weight;
+            this.price = price;
+        }
+    }
+
+    public static void main(String[] args) throws Exception{
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        Jewel[] jewels = new Jewel[n];
+        for(int i=0; i<n; i++){
+            st = new StringTokenizer(br.readLine());
+            int m = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            jewels[i] = new Jewel(m, v);
+        }
+
+        // 보석들을 무게 오름차순으로 정렬
+        Arrays.sort(jewels, new Comparator<Jewel>(){
+            @Override
+            public int compare(Jewel o1, Jewel o2){
+                return o1.weight-o2.weight;
+            }
+        });
+
+        // 가방의 무게를 오름차순으로 정렬
+        List<Integer> bags = new ArrayList<>();
+        for(int i=0; i<k; i++){
+            int c = Integer.parseInt(br.readLine());
+            bags.add(c);
+        }
+        Collections.sort(bags);
+
+        // 우선순위큐는 가격이 내림차순으로 정렬
+        PriorityQueue<Jewel> pq = new PriorityQueue<>(new Comparator<Jewel>() {
+            @Override
+            public int compare(Jewel o1, Jewel o2) {
+                return o2.price-o1.price;
+            }
+        });
+
+        int idx = 0;
+        long total = 0;
+        for(int i=0, len=bags.size(); i<len; i++){
+            int c = bags.get(i);
+            // 현재 가방의 무게보다 작은 보석들을 모두 pq에 삽입
+            while (idx<n && jewels[idx].weight<=c){
+                pq.offer(jewels[idx]);
+                idx++;
+            }
+            // pq에서 가격이 제일 비싼 보석 추출
+            if(!pq.isEmpty())
+                total += pq.poll().price;
+        }
+        System.out.println(total);
+    }
+}
+```


### PR DESCRIPTION
완전탐색으로 풀면 O(N^2)=O(30만*30만)이므로 시간 초과 판정이 뜹니다.
어떤 알고리즘으로 풀면 좋을까 생각하다가 우선순위 큐, 정렬로 접근하였습니다.
하지만 살짝 꼬이는 바람에,, 풀지는 못했고 답을 봤습니다.

핵심 로직은 아래와 같습니다.
1. 보석은 무게에 대해 오름차순 정렬합니다.
2. 가방도 담을 수 있는 무게에 대해 오름차순 정렬합니다.
3. 가방 배열을 순회하면서 특정 가방의 무게보다 작은 보석을 모두 우선순위 큐에 넣고 그중에 가격이 제일 비싼 보석을 선택하면 됩니다.
이때 우선순위큐 정렬 조건은 가격에 대해 내림차순합니다.

이렇게 구현하면 이중 for문 대비 한번 탐색한 보석은 다시 검사하지 않아도 되기 때문에 시간 복잡도가 O(N)이 됩니다.
전체 시간 복잡도는 정렬로 인해 O(nlogn)
